### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -40,7 +40,7 @@ class action_plugin_refnotes extends DokuWiki_Action_Plugin {
     /**
      * Register callbacks
      */
-    public function register($controller) {
+    public function register(Doku_Event_Handler $controller) {
         $this->afterParserHandlerDone->register($controller);
         $this->beforeAjaxCallUnknown->register($controller);
         $this->beforeParserCacheUse->register($controller);

--- a/syntax/notes.php
+++ b/syntax/notes.php
@@ -51,7 +51,7 @@ class syntax_plugin_refnotes_notes extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    public function handle($match, $state, $pos, $handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         switch ($match{0}) {
             case '~':
                 return $this->handleBasic($match);
@@ -66,7 +66,7 @@ class syntax_plugin_refnotes_notes extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    public function render($mode, $renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         try {
             if($mode == 'xhtml') {
                 switch ($data[0]) {

--- a/syntax/references.php
+++ b/syntax/references.php
@@ -114,7 +114,7 @@ class syntax_plugin_refnotes_references extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    public function handle($match, $state, $pos, $handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         $result = refnotes_parser_core::getInstance()->canHandle($state);
 
         if ($result) {
@@ -139,7 +139,7 @@ class syntax_plugin_refnotes_references extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    public function render($mode, $renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         $result = false;
 
         try {


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.