### PR TITLE
basic footnotes odt export 

### DIFF
--- a/core.php
+++ b/core.php
@@ -350,20 +350,19 @@ class refnotes_renderer_core extends refnotes_core {
     /**
      *
      */
-    public function renderNotes($namespaceName, $limit) {
+    public function renderNotes($mode, $namespaceName, $limit) {
         $this->clearNamespaceMapping($namespaceName);
-
         $html = '';
 
         if ($namespaceName == '*') {
             foreach ($this->namespace as $namespace) {
-                $html .= $namespace->renderNotes();
+                $html .= $namespace->renderNotes($mode);
             }
         }
         else {
             $namespace = $this->findNamespace($namespaceName);
             if ($namespace != NULL) {
-                $html = $namespace->renderNotes($limit);
+                $html = $namespace->renderNotes($mode, $limit);
             }
         }
 

--- a/namespace.php
+++ b/namespace.php
@@ -436,15 +436,15 @@ class refnotes_namespace {
     /**
      *
      */
-    public function renderNotes($limit = '') {
+    public function renderNotes($mode, $limit = '') {
         $this->resetScope();
-        $html = '';
+        $doc = '';
 
         if (count($this->scope) > 0) {
-            $html = $this->getCurrentScope()->renderNotes($limit);
+            $doc = $this->getCurrentScope()->renderNotes($mode, $limit);
         }
 
-        return $html;
+        return $doc;
     }
 
     /**

--- a/note.php
+++ b/note.php
@@ -245,13 +245,13 @@ class refnotes_renderer_note extends refnotes_note {
     /**
      *
      */
-    public function render() {
-        $html = $this->scope->getRenderer()->renderNote($this, $this->reference);
+    public function render($mode) {
+        $doc = $this->scope->getRenderer()->renderNote($mode, $this, $this->reference);
 
         $this->reference = array();
         $this->processed = true;
 
-        return $html;
+        return $doc;
     }
 }
 

--- a/reference.php
+++ b/reference.php
@@ -118,14 +118,14 @@ class refnotes_renderer_reference extends refnotes_reference {
     /**
      *
      */
-    public function render() {
-        $html = '';
+    public function render($mode) {
+        $doc = '';
 
         if (!$this->hidden) {
-            $html = $this->note->getScope()->getRenderer()->renderReference($this);
+            $doc = $this->note->getScope()->getRenderer()->renderReference($mode, $this);
         }
 
-        return $html;
+        return $doc;
     }
 }
 

--- a/rendering.php
+++ b/rendering.php
@@ -50,7 +50,7 @@ abstract class refnotes_renderer_base {
     /**
      *
      */
-    abstract public function renderReference($reference);
+    abstract public function renderReference($mode, $reference);
 
     /**
      *
@@ -60,7 +60,7 @@ abstract class refnotes_renderer_base {
     /**
      *
      */
-    abstract public function renderNote($note, $reference);
+    abstract public function renderNote($mode, $note, $reference);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -113,8 +113,8 @@ class refnotes_renderer extends refnotes_renderer_base {
     /**
      *
      */
-    public function renderReference($reference) {
-        return $this->referenceRenderer->renderReference($reference);
+    public function renderReference($mode, $reference) {
+        return $this->referenceRenderer->renderReference($mode, $reference);
     }
 
     /**
@@ -143,8 +143,8 @@ class refnotes_renderer extends refnotes_renderer_base {
     /**
      *
      */
-    public function renderNote($note, $reference) {
-        return $this->noteRenderer->renderNote($note, $reference);
+    public function renderNote($mode, $note, $reference) {
+        return $this->noteRenderer->renderNote($mode, $note, $reference);
     }
 }
 
@@ -240,6 +240,8 @@ class refnotes_renderer_data {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class refnotes_basic_renderer extends refnotes_renderer_base {
 
+    protected $renderedNoteId = array();
+
     /**
      *
      */
@@ -257,15 +259,15 @@ class refnotes_basic_renderer extends refnotes_renderer_base {
     /**
      *
      */
-    public function renderReference($reference) {
+    public function renderReference($mode, $reference) {
         if ($reference->isInline()) {
-            $html = $this->renderInlineReference($reference);
+            $doc = $this->renderInlineReference($reference);
         }
         else {
-            $html = $this->renderRegularReference($reference);
+            $doc = $this->renderRegularReference($mode, $reference);
         }
 
-        return $html;
+        return $doc;
     }
 
     /**
@@ -288,9 +290,28 @@ class refnotes_basic_renderer extends refnotes_renderer_base {
     }
 
     /**
+     * 
+     */
+    public function renderNote($mode, $note, $reference) {
+        $doc = '';
+
+        switch ($mode) {
+            case 'xhtml':
+                $doc = $this->renderNoteXhtml($note, $reference);
+                break;
+
+            case 'odt':
+                $doc = $this->renderNoteOdt($note, $reference);
+                break;
+        }
+
+        return $doc;
+    }
+
+    /**
      *
      */
-    public function renderNote($note, $reference) {
+    protected function renderNoteXhtml($note, $reference) {
         $html = '<div class="' . $this->renderNoteClass() . '">' . DOKU_LF;
         $html .= $this->renderBackReferences($note, $reference);
         $html .= '<span id="' . $note->getAnchorName() . ':text">' . DOKU_LF;
@@ -300,6 +321,15 @@ class refnotes_basic_renderer extends refnotes_renderer_base {
         $this->rendered = true;
 
         return $html;
+    }
+
+    /**
+     *
+     */
+    protected function renderNoteOdt($note, $reference) {
+        $this->rendered = true;
+        
+        return '';
     }
 
     /**
@@ -330,9 +360,28 @@ class refnotes_basic_renderer extends refnotes_renderer_base {
     }
 
     /**
+     * 
+     */
+    protected function renderRegularReference($mode, $reference) {
+        $doc = '';
+
+        switch ($mode) {
+            case 'xhtml':
+                $doc = $this->renderRegularReferenceXhtml($reference);
+                break;
+
+            case 'odt':
+                $doc = $this->renderRegularReferenceOdt($reference);
+                break;
+        }
+
+        return $doc;
+    }
+
+    /**
      *
      */
-    protected function renderRegularReference($reference) {
+    protected function renderRegularReferenceXhtml($reference) {
         $noteName = $reference->getNote()->getAnchorName();
         $referenceName = $reference->getAnchorName();
         $class = $this->renderReferenceClass();
@@ -348,6 +397,39 @@ class refnotes_basic_renderer extends refnotes_renderer_base {
         $html .= $fontClose . $baseClose;
 
         return $html;
+    }
+
+    /**
+     *
+     */
+    protected function renderRegularReferenceOdt($reference) {
+        $xmlOdt = '';
+        $note = $reference->getNote();
+        $noteId = $note->getId();
+        $refId = $reference->getId();
+
+        // Check to see if this note has been seen before
+
+        if (array_search($noteId, $this->renderedNoteId) === false) {
+            // new note, add it to the $renderedNoteId array
+            $this->renderedNoteId[] = $noteId;
+
+            $xmlOdt .= '<text:note text:id="refnote' . $refId . '" text:note-class="footnote">';
+            $xmlOdt .= '<text:note-citation text:label="' . $refId . '">' . $refId . '</text:note-citation>';
+            $xmlOdt .= '<text:note-body>';
+            $xmlOdt .= '<text:p>' . $note->getText();
+            $xmlOdt .= '</text:p>';
+            $xmlOdt .= '</text:note-body>';
+            $xmlOdt .= '</text:note>';
+        }
+        else {
+            // Seen this one before - just reference it FIXME: style isn't correct
+            $xmlOdt = '<text:note-ref text:note-class="footnote" text:ref-name="refnote' . $noteId . '">';
+            $xmlOdt .= $refId;
+            $xmlOdt .= '</text:note-ref>';
+        }
+
+        return $xmlOdt;
     }
 
     /**

--- a/scope.php
+++ b/scope.php
@@ -138,21 +138,21 @@ class refnotes_scope {
     /**
      *
      */
-    public function renderNotes($limit) {
+    public function renderNotes($mode, $limit) {
         $block = new refnotes_note_block_iterator($this->note, $limit);
-        $html = '';
+        $doc = '';
 
         foreach ($block as $note) {
-            $html .= $note->render();
+            $doc .= $note->render($mode);
         }
 
-        if ($html != '') {
+        if ($mode == 'xhtml' && $doc != '') {
             $open = $this->getRenderer()->renderNotesSeparator() . '<div class="notes">' . DOKU_LF;
             $close = '</div>' . DOKU_LF;
-            $html = $open . $html . $close;
+            $doc = $open . $doc . $close;
         }
 
-        return $html;
+        return $doc;
     }
 
     /**

--- a/syntax/notes.php
+++ b/syntax/notes.php
@@ -79,9 +79,18 @@ class syntax_plugin_refnotes_notes extends DokuWiki_Syntax_Plugin {
                         break;
 
                     case 'render':
-                        $this->renderNotes($renderer, $data[1]);
+                        $this->renderNotes($mode, $renderer, $data[1]);
                         break;
                 }
+                return true;
+            }
+            elseif ($mode == 'odt') {
+                switch ($data[0]) {
+                    case 'render':
+                        $this->renderNotes($mode, $renderer, $data[1]);
+                        break;
+                }
+
                 return true;
             }
         }
@@ -193,13 +202,13 @@ class syntax_plugin_refnotes_notes extends DokuWiki_Syntax_Plugin {
     /**
      *
      */
-    private function renderNotes($renderer, $attribute) {
+    private function renderNotes($mode, $renderer, $attribute) {
         $limit = array_key_exists('limit', $attribute) ? $attribute['limit'] : '';
-        $html = refnotes_renderer_core::getInstance()->renderNotes($attribute['ns'], $limit);
+        $doc = refnotes_renderer_core::getInstance()->renderNotes($mode, $attribute['ns'], $limit);
 
-        if ($html != '') {
+        if ($mode == 'xhtml' && $doc != '') {
             $renderer->doc .= '<div class="refnotes">' . DOKU_LF;
-            $renderer->doc .= $html;
+            $renderer->doc .= $doc;
             $renderer->doc .= '</div>' . DOKU_LF;
         }
     }

--- a/syntax/references.php
+++ b/syntax/references.php
@@ -145,7 +145,8 @@ class syntax_plugin_refnotes_references extends DokuWiki_Syntax_Plugin {
         try {
             switch ($mode) {
                 case 'xhtml':
-                    $result = $this->renderXhtml($renderer, $data);
+                case 'odt':
+                    $result = $this->renderReferences($mode, $renderer, $data);
                     break;
 
                 case 'metadata':
@@ -188,16 +189,16 @@ class syntax_plugin_refnotes_references extends DokuWiki_Syntax_Plugin {
     }
 
     /**
-     *
+     * 
      */
-    public function renderXhtml($renderer, $data) {
+    public function renderReferences($mode, $renderer, $data) {
         switch ($data[0]) {
             case 'start':
                 $this->noteCapture->start($renderer);
                 break;
-
+        
             case 'render':
-                $this->renderReference($renderer, $data[1], (count($data) > 2) ? $data[2] : array());
+                $this->renderReference($mode, $renderer, $data[1], (count($data) > 2) ? $data[2] : array());
                 break;
         }
 
@@ -207,7 +208,7 @@ class syntax_plugin_refnotes_references extends DokuWiki_Syntax_Plugin {
     /**
      * Stops renderer output capture and renders the reference link
      */
-    private function renderReference($renderer, $attributes, $data) {
+    private function renderReference($mode, $renderer, $attributes, $data) {
         $reference = refnotes_renderer_core::getInstance()->addReference($attributes, $data);
         $text = $this->noteCapture->stop();
 
@@ -215,7 +216,7 @@ class syntax_plugin_refnotes_references extends DokuWiki_Syntax_Plugin {
             $reference->getNote()->setText($text);
         }
 
-        $renderer->doc .= $reference->render();
+        $renderer->doc .= $reference->render($mode);
     }
 
     /**


### PR DESCRIPTION
only basic footnotes implemented
issue  https://github.com/dwp-forge/refnotes/issues/38
NOT implemented:
- notes not separated by horizontal line
- render the notes at any place
- structered notes
- hidden references
- inline notes