### PR TITLE
Fix for the DokuWiki_PluginTrait::lang property, which is now protected

### DIFF
--- a/action.php
+++ b/action.php
@@ -47,6 +47,31 @@ class action_plugin_refnotes extends DokuWiki_Action_Plugin {
         $this->beforeParserWikitextPreprocess->register($controller);
         $this->beforeTplMetaheaderOutput->register($controller);
     }
+
+	/**
+	 * A hack to retrieve localization by prefix.
+	 */
+    public function getActionLocaleByPrefix($prefix, $strip = true) {
+        if(!$this->localised) $this->setupLocale();
+
+        if ($strip) {
+            $pattern = '/^' . $prefix . '_(.+)$/';
+        }
+        else {
+            $pattern = '/^(' . $prefix . '_.+)$/';
+        }
+
+        $result = array();
+
+		print_r($this->plugin);
+        foreach ($this->lang as $key => $value) {
+            if (preg_match($pattern, $key, $match) == 1) {
+                $result[$match[1]] = $value;
+            }
+        }
+        return $result;
+    }
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/action.php
+++ b/action.php
@@ -48,9 +48,9 @@ class action_plugin_refnotes extends DokuWiki_Action_Plugin {
         $this->beforeTplMetaheaderOutput->register($controller);
     }
 
-	/**
-	 * A hack to retrieve localization by prefix.
-	 */
+    /**
+     * A hack to retrieve localization by prefix.
+     */
     public function getActionLocaleByPrefix($prefix, $strip = true) {
         if(!$this->localised) $this->setupLocale();
 

--- a/locale.php
+++ b/locale.php
@@ -58,23 +58,6 @@ class refnotes_localization {
      *
      */
     public function getByPrefix($prefix, $strip = true) {
-        $this->plugin->setupLocale();
-
-        if ($strip) {
-            $pattern = '/^' . $prefix . '_(.+)$/';
-        }
-        else {
-            $pattern = '/^(' . $prefix . '_.+)$/';
-        }
-
-        $result = array();
-
-        foreach ($this->plugin->lang as $key => $value) {
-            if (preg_match($pattern, $key, $match) == 1) {
-                $result[$match[1]] = $value;
-            }
-        }
-
-        return $result;
+        return $this->plugin->getActionLocaleByPrefix($prefix, $strip);
     }
 }


### PR DESCRIPTION
# Why?
- Because the administration page shows an error complaining about the access to $lang property being restricted.
- The root cause is the transformation of the ``inc/plugin.php`` class between "Frusterick Manners" and "Greebo", in which the ``lang`` property has become ``protected``.

# Correction
- I've moved the ``getByPrefix`` functionality into the ``action_plugin_refnotes``: from there, the ``$lang`` property is accessible.
- I've transformed the ``getByPrefix`` into a mere alias.

With this modification, the ___RefNotes__ plugin seems compatible with "Greebo".
 