### PR TITLE
Prevent direct access to '$this->plugin->lang' ('lang' variable of class 'DokuWiki_Plugin')

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -68,7 +68,7 @@ class admin_plugin_refnotes extends DokuWiki_Admin_Plugin {
      * them as part of the page and then load them into the LANG array on the client side.
      */
     private function printLanguageStrings() {
-        $lang = $this->locale->getByPrefix('js');
+        $lang = $this->locale->getLangJSPrefix();
 
         $this->html->ptln('<div id="refnotes-lang" style="display: none;">');
 

--- a/database.php
+++ b/database.php
@@ -70,7 +70,7 @@ class refnotes_reference_database {
      */
     private function loadKeys() {
         $locale = refnotes_localization::getInstance();
-        foreach ($locale->getByPrefix('dbk') as $key => $text) {
+        foreach (getLangDBKPrefix() as $key => $text) {
             $this->key[$this->normalizeKeyText($text)] = $key;
         }
     }

--- a/locale.php
+++ b/locale.php
@@ -57,22 +57,46 @@ class refnotes_localization {
     /**
      *
      */
-    public function getByPrefix($prefix, $strip = true) {
-        $this->plugin->setupLocale();
+    public function getLangJSPrefix() {
+        $jslang = array('js_status', 'js_loading', 'js_loaded',
+                        'js_loading_failed', 'js_invalid_data',
+                        'js_saving', 'js_saved', 'js_saving_failed',
+                        'js_invalid_ns_name', 'js_ns_name_exists',
+                        'js_delete_ns', 'js_invalid_note_name',
+                        'js_note_name_exists', 'js_delete_note',
+                        'js_unsaved');
 
-        if ($strip) {
-            $pattern = '/^' . $prefix . '_(.+)$/';
-        }
-        else {
-            $pattern = '/^(' . $prefix . '_.+)$/';
-        }
+        $this->plugin->setupLocale();
 
         $result = array();
 
-        foreach ($this->plugin->lang as $key => $value) {
-            if (preg_match($pattern, $key, $match) == 1) {
-                $result[$match[1]] = $value;
-            }
+        foreach ($jslang as $key) {
+            $newkey = substr($key, 2);
+            $result[$newkey] = $this->plugin->getLang($key);
+        }
+
+        return $result;
+    }
+
+    /**
+     *
+     */
+    public function getLangDBKPrefix() {
+        $dbklang = array('dbk_author', 'dbk_authors', 'dbk_chapter',
+                         'dbk_edition', 'dbk_isbn', 'dbk_issn',
+                         'dbk_journal', 'dbk_month', 'dbk_note-name',
+                         'dbk_note-page', 'dbk_note-pages', 'dbk_note-text',
+                         'dbk_page', 'dbk_pages', 'dbk_published',
+                         'dbk_publisher', 'dbk_ref-author', 'dbk_ref-authors',
+                         'dbk_title', 'dbk_url', 'dbk_volume', 'dbk_year');
+
+        $this->plugin->setupLocale();
+
+        $result = array();
+
+        foreach ($dbklang as $key) {
+            $newkey = substr($key, 3);
+            $result[$newkey] = $this->plugin->getLang($key);
         }
 
         return $result;


### PR DESCRIPTION
This is a very simple approach to fix the problem. New ```js_``` and ```dbk_``` strings would need to be added manually now to functions ```getLangJSPrefix()``` and ```getLangDBKPrefix()```. But it might be acceptable as there were not much changes in the past.
