### PR TITLE
fix(mort): PHP Fatal error caused by missing inc/indexer.php on newer DokuWiki versions

### DIFF
--- a/bibtex.php
+++ b/bibtex.php
@@ -180,6 +180,12 @@ class refnotes_bibtex_mode extends \dokuwiki\Parsing\ParserMode\AbstractMode {
             $this->Lexer->addExitPattern($pattern, $this->name);
         }
     }
+    /**
+     * Required by AbstractMode
+     */
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
+        return false;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/bibtex.php
+++ b/bibtex.php
@@ -180,12 +180,6 @@ class refnotes_bibtex_mode extends \dokuwiki\Parsing\ParserMode\AbstractMode {
             $this->Lexer->addExitPattern($pattern, $this->name);
         }
     }
-    /**
-     * Required by AbstractMode
-     */
-    public function handle($match, $state, $pos, Doku_Handler $handler) {
-        return false;
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/database.php
+++ b/database.php
@@ -106,7 +106,9 @@ class refnotes_reference_database {
         global $conf;
 
         if (file_exists($conf['indexdir'] . '/page.idx')) {
-            require_once(DOKU_INC . 'inc/indexer.php');
+            if (file_exists(DOKU_INC . 'inc/indexer.php')) {
+                require_once(DOKU_INC . 'inc/indexer.php');
+            }
 
             $pageIndex = idx_getIndex('page', '');
             $namespace = refnotes_configuration::getSetting('reference-db-namespace');


### PR DESCRIPTION
### Description
This PR fixes a fatal error that occurs in newer versions of DokuWiki (e.g. Mort and newer) where the `inc/indexer.php` file has been completely removed in favor of the new object-oriented search classes.
When running the plugin on a recent DokuWiki installation, it crashes with the following error while editing a page:
```php
Error: Failed opening required '/home/example/web/wiki.example.com/public_html/inc/indexer.php' (include_path='.:/usr/share/php')
/home/nethouse/web/wiki.example.com/public_html/lib/plugins/refnotes/database.php(109)
```
The underlying DokuWiki change is tracked in [dokuwiki/dokuwiki#4646](https://github.com/dokuwiki/dokuwiki/pull/4646). While that PR introduces a `LegacyIndexer` and maintains the `idx_getIndex` function via the compatibility layer (`inc/deprecated.php`), the `inc/indexer.php` file itself was deleted, causing `require_once(DOKU_INC . 'inc/indexer.php');` to fail.

### Changes
- Added a `file_exists` check before requiring `inc/indexer.php`.
- Retained the usage of `idx_getIndex`, which is properly handled by DokuWiki's backwards-compatibility layer.